### PR TITLE
feat(feedback): add GitHub issue popover

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -29,6 +29,7 @@ import {
 } from "../components/ui/sidebar";
 import type { AISQLAssistantRequest } from "../features/ai-assistant/AiAssistantPanel";
 import { ConnectionPanel } from "../features/connections/ConnectionPanel";
+import { FeedbackPopover } from "../features/feedback/FeedbackPopover";
 import { QueryEditor } from "../features/query-editor/QueryEditor";
 import { QueryPlanView } from "../features/query-plan/QueryPlanView";
 import { ResultsGrid } from "../features/results-grid/ResultsGrid";
@@ -732,9 +733,14 @@ export function App() {
             </div>
 
             <div className="flex min-w-0 items-center gap-2">
+              <FeedbackPopover
+                version={
+                  model.appUpdateState.versionInfo?.currentVersion || "dev"
+                }
+              />
               <a
                 aria-label="Star DataPanel on GitHub"
-                className="hidden h-7 items-center gap-2 rounded-md border border-line bg-control/[0.04] px-3 text-sm font-medium text-zinc-200 transition hover:bg-control/[0.07] hover:text-zinc-100 lg:inline-flex [&>svg]:h-3.5 [&>svg]:w-3.5 [&>svg]:shrink-0"
+                className="hidden h-7 items-center gap-2 rounded-md border border-line bg-control/[0.04] px-3 text-sm font-medium text-zinc-200 transition hover:bg-control/[0.07] hover:text-zinc-100 xl:inline-flex [&>svg]:h-3.5 [&>svg]:w-3.5 [&>svg]:shrink-0"
                 href={githubRepositoryUrl}
                 onClick={openGitHubRepository}
                 rel="noreferrer"

--- a/frontend/src/features/feedback/FeedbackPopover.tsx
+++ b/frontend/src/features/feedback/FeedbackPopover.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useRef, useState } from "react";
+import { BrowserOpenURL } from "../../../wailsjs/runtime/runtime";
+import { Button } from "../../components/ui/Button";
+import { textInputBehaviorProps } from "../../lib/text-input";
+import {
+  buildFeedbackIssueUrl,
+  maxFeedbackLength,
+} from "./lib/githubIssue";
+
+interface Props {
+  version?: string;
+}
+
+interface WailsRuntimeWindow extends Window {
+  runtime?: {
+    BrowserOpenURL?: unknown;
+  };
+}
+
+export function FeedbackPopover({ version }: Props) {
+  const [open, setOpen] = useState(false);
+  const [message, setMessage] = useState("");
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const canContinue = message.trim().length > 0;
+
+  useEffect(() => {
+    if (!open) return undefined;
+
+    const focusFrame = window.requestAnimationFrame(() => {
+      textareaRef.current?.focus();
+    });
+
+    function handlePointerDown(event: PointerEvent) {
+      if (
+        event.target instanceof Node &&
+        !containerRef.current?.contains(event.target)
+      ) {
+        setOpen(false);
+      }
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") setOpen(false);
+    }
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.cancelAnimationFrame(focusFrame);
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
+  function continueToGitHub() {
+    const feedback = message.trim();
+    if (!feedback) return;
+
+    openExternalUrl(buildFeedbackIssueUrl(feedback, version));
+    setMessage("");
+    setOpen(false);
+  }
+
+  return (
+    <div ref={containerRef} className="relative shrink-0">
+      <Button
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        className="rounded-full px-3 text-zinc-300"
+        type="button"
+        onClick={() => setOpen((current) => !current)}
+      >
+        Feedback
+      </Button>
+
+      {open ? (
+        <div
+          aria-label="Share feedback"
+          className="absolute left-0 top-[calc(100%+10px)] z-50 w-[380px] overflow-hidden rounded-lg border border-line bg-surface-850 shadow-2xl"
+          role="dialog"
+        >
+          <div className="p-4">
+            <textarea
+              {...textInputBehaviorProps}
+              ref={textareaRef}
+              aria-label="Feedback"
+              className="h-32 resize-none bg-surface-900 p-3 font-sans text-sm leading-5 text-zinc-100 placeholder:text-muted"
+              maxLength={maxFeedbackLength}
+              placeholder="How can we improve DataPanel?"
+              value={message}
+              onChange={(event) => setMessage(event.target.value)}
+              onKeyDown={(event) => {
+                if (
+                  (event.metaKey || event.ctrlKey) &&
+                  event.key === "Enter"
+                ) {
+                  event.preventDefault();
+                  continueToGitHub();
+                }
+              }}
+            />
+          </div>
+          <div className="flex items-center justify-between gap-3 border-t border-line bg-surface-900/50 px-4 py-3">
+            <span className="text-xs text-muted">
+              Review and submit on GitHub
+            </span>
+            <Button
+              disabled={!canContinue}
+              type="button"
+              variant="primary"
+              onClick={continueToGitHub}
+            >
+              Continue to GitHub
+            </Button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function openExternalUrl(url: string) {
+  if ((window as WailsRuntimeWindow).runtime?.BrowserOpenURL) {
+    BrowserOpenURL(url);
+    return;
+  }
+  window.open(url, "_blank", "noopener,noreferrer");
+}

--- a/frontend/src/features/feedback/lib/githubIssue.ts
+++ b/frontend/src/features/feedback/lib/githubIssue.ts
@@ -1,0 +1,34 @@
+const githubNewIssueUrl =
+  "https://github.com/aquibbaig/datapanel/issues/new";
+const feedbackTitlePrefix = "[Feedback] ";
+const maxIssueTitleLength = 100;
+
+export const maxFeedbackLength = 2000;
+
+export function buildFeedbackIssueUrl(message: string, version?: string) {
+  const feedback = message.trim();
+  const firstLine =
+    feedback
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean) || "User feedback";
+  const titleSummary = truncateText(
+    firstLine.replace(/\s+/g, " "),
+    maxIssueTitleLength - feedbackTitlePrefix.length,
+  );
+  const normalizedVersion = version?.trim().replace(/\s+/g, " ");
+  const body = normalizedVersion
+    ? `${feedback}\n\n---\nDataPanel version: ${normalizedVersion}`
+    : feedback;
+  const url = new URL(githubNewIssueUrl);
+
+  url.searchParams.set("title", `${feedbackTitlePrefix}${titleSummary}`);
+  url.searchParams.set("body", body);
+  return url.toString();
+}
+
+function truncateText(value: string, maxLength: number) {
+  const characters = Array.from(value);
+  if (characters.length <= maxLength) return value;
+  return `${characters.slice(0, maxLength - 1).join("").trimEnd()}…`;
+}


### PR DESCRIPTION
## Summary
- add a compact header feedback popover
- open a prefilled GitHub issue using the existing browser session
- include only the feedback message and DataPanel version
- keep the control usable across themes and minimum window width

## Verification
- npm run typecheck
- npm run build
- manually verified dark and light themes, keyboard interactions, draft clearing, URL encoding, and minimum window layout